### PR TITLE
Make single method by sorting param keys instead of many permutations

### DIFF
--- a/lib/active_remote/cached.rb
+++ b/lib/active_remote/cached.rb
@@ -77,14 +77,6 @@ module ActiveRemote
       def _create_cached_finder_for(cached_finder_key, options = {})
         cached_finder_key_set = [ cached_finder_key ].flatten.sort
 
-        ##
-        # Run each permutation of the arguments passed in
-        # and define each finder/searcher
-        #
-        cached_finder_key_set.permutation do |arguments|
-          
-        end
-
         delete_method_name = _cached_delete_method_name(cached_finder_key_set)
         exist_find_method_name = _cached_exist_find_method_name(cached_finder_key_set)
         exist_search_method_name = _cached_exist_search_method_name(cached_finder_key_set)

--- a/lib/active_remote/cached.rb
+++ b/lib/active_remote/cached.rb
@@ -47,7 +47,7 @@ module ActiveRemote
 
       def cached_find(argument_hash, options = {})
         method_name = _cached_find_method_name(argument_hash.keys)
-        arguments = argument_hash.values
+        arguments = argument_hash.keys.sort.map { |k| argument_hash[k] }
 
         if block_given?
           __send__(method_name, *arguments, options) do
@@ -60,7 +60,7 @@ module ActiveRemote
 
       def cached_search(argument_hash, options = {})
         method_name = _cached_search_method_name(argument_hash.keys)
-        arguments = argument_hash.values
+        arguments = argument_hash.keys.sort.map { |k| argument_hash[k] }
 
         if block_given?
           __send__(method_name, *arguments, options) do
@@ -82,57 +82,59 @@ module ActiveRemote
         # and define each finder/searcher
         #
         cached_finder_key_set.permutation do |arguments|
-          delete_method_name = _cached_delete_method_name(arguments)
-          exist_find_method_name = _cached_exist_find_method_name(arguments)
-          exist_search_method_name = _cached_exist_search_method_name(arguments)
-          find_method_name = _cached_find_method_name(arguments)
-          search_method_name = _cached_search_method_name(arguments)
-          search_bang_method_name = "#{search_method_name}!"
+          
+        end
 
-          unless self.respond_to?(delete_method_name)
-            _define_cached_delete_method(delete_method_name, arguments, options)
-          end
+        delete_method_name = _cached_delete_method_name(cached_finder_key_set)
+        exist_find_method_name = _cached_exist_find_method_name(cached_finder_key_set)
+        exist_search_method_name = _cached_exist_search_method_name(cached_finder_key_set)
+        find_method_name = _cached_find_method_name(cached_finder_key_set)
+        search_method_name = _cached_search_method_name(cached_finder_key_set)
+        search_bang_method_name = "#{search_method_name}!"
 
-          unless self.respond_to?(exist_find_method_name)
-            _define_cached_exist_find_method(exist_find_method_name, arguments, options)
-          end
+        unless self.respond_to?(delete_method_name)
+          _define_cached_delete_method(delete_method_name, cached_finder_key_set, options)
+        end
 
-          unless self.respond_to?(exist_search_method_name)
-            _define_cached_exist_search_method(exist_search_method_name, arguments, options)
-          end
+        unless self.respond_to?(exist_find_method_name)
+          _define_cached_exist_find_method(exist_find_method_name, cached_finder_key_set, options)
+        end
 
-          unless self.respond_to?(find_method_name)
-            _define_cached_find_method(find_method_name, arguments, options)
-          end
+        unless self.respond_to?(exist_search_method_name)
+          _define_cached_exist_search_method(exist_search_method_name, cached_finder_key_set, options)
+        end
 
-          unless self.respond_to?(search_bang_method_name)
-            _define_cached_search_bang_method(search_bang_method_name, arguments, options)
-          end
+        unless self.respond_to?(find_method_name)
+          _define_cached_find_method(find_method_name, cached_finder_key_set, options)
+        end
 
-          unless self.respond_to?(search_method_name)
-            _define_cached_search_method(search_method_name, arguments, options)
-          end
+        unless self.respond_to?(search_bang_method_name)
+          _define_cached_search_bang_method(search_bang_method_name, cached_finder_key_set, options)
+        end
+
+        unless self.respond_to?(search_method_name)
+          _define_cached_search_method(search_method_name, cached_finder_key_set, options)
         end
       end
 
       def _cached_delete_method_name(arguments)
-        "cached_delete_by_#{arguments.join('_and_')}"
+        "cached_delete_by_#{arguments.sort.join('_and_')}"
       end
 
       def _cached_exist_find_method_name(arguments)
-        "cached_exist_find_by_#{arguments.join('_and_')}"
+        "cached_exist_find_by_#{arguments.sort.join('_and_')}"
       end
 
       def _cached_exist_search_method_name(arguments)
-        "cached_exist_search_by_#{arguments.join('_and_')}"
+        "cached_exist_search_by_#{arguments.sort.join('_and_')}"
       end
 
       def _cached_find_method_name(arguments)
-        "cached_find_by_#{arguments.join('_and_')}"
+        "cached_find_by_#{arguments.sort.join('_and_')}"
       end
 
       def _cached_search_method_name(arguments)
-        "cached_search_by_#{arguments.join('_and_')}"
+        "cached_search_by_#{arguments.sort.join('_and_')}"
       end
 
       def _define_cached_delete_method(method_name, *method_arguments, cached_finder_options)

--- a/spec/active_remote/cached_delete_methods_spec.rb
+++ b/spec/active_remote/cached_delete_methods_spec.rb
@@ -23,7 +23,7 @@ describe DeleteMethodClass do
     end
 
     it "creates 'cached_delete_by_user_guid_and_client_guid'" do
-      DeleteMethodClass.must_respond_to("cached_delete_by_user_guid_and_client_guid")
+      DeleteMethodClass.must_respond_to("cached_delete_by_client_guid_and_user_guid")
     end
 
     it "creates 'cached_delete_by_client_guid_and_user_guid'" do
@@ -31,15 +31,11 @@ describe DeleteMethodClass do
     end
 
     it "creates 'cached_delete_by_derp_and_user_guid_and_client_guid'" do
-      DeleteMethodClass.must_respond_to("cached_delete_by_derp_and_user_guid_and_client_guid")
+      DeleteMethodClass.must_respond_to("cached_delete_by_client_guid_and_derp_and_user_guid")
     end
 
     it "creates 'cached_delete_by_client_guid_and_derp_and_user_guid'" do
       DeleteMethodClass.must_respond_to("cached_delete_by_client_guid_and_derp_and_user_guid")
-    end
-
-    it "creates 'cached_delete_by_client_guid_and_user_guid_and_derp'" do
-      DeleteMethodClass.must_respond_to("cached_delete_by_client_guid_and_user_guid_and_derp")
     end
   end
 end

--- a/spec/active_remote/cached_exist_methods_spec.rb
+++ b/spec/active_remote/cached_exist_methods_spec.rb
@@ -30,12 +30,12 @@ describe ExistMethodClass do
       ExistMethodClass.must_respond_to("cached_exist_search_by_user_guid")
     end
 
-    it "creates 'cached_exist_find_by_user_guid_and_client_guid'" do
-      ExistMethodClass.must_respond_to("cached_exist_find_by_user_guid_and_client_guid")
+    it "creates 'cached_exist_find_by_client_guid_and_user_guid'" do
+      ExistMethodClass.must_respond_to("cached_exist_find_by_client_guid_and_user_guid")
     end
 
-    it "creates 'cached_exist_search_by_user_guid_and_client_guid'" do
-      ExistMethodClass.must_respond_to("cached_exist_search_by_user_guid_and_client_guid")
+    it "creates 'cached_exist_search_by_client_guid_and_user_guid'" do
+      ExistMethodClass.must_respond_to("cached_exist_search_by_client_guid_and_user_guid")
     end
 
     it "creates 'cached_exist_find_by_client_guid_and_user_guid'" do
@@ -46,12 +46,12 @@ describe ExistMethodClass do
       ExistMethodClass.must_respond_to("cached_exist_search_by_client_guid_and_user_guid")
     end
 
-    it "creates 'cached_exist_find_by_derp_and_user_guid_and_client_guid'" do
-      ExistMethodClass.must_respond_to("cached_exist_find_by_derp_and_user_guid_and_client_guid")
+    it "creates 'cached_exist_find_by_client_guid_and_derp_and_user_guid'" do
+      ExistMethodClass.must_respond_to("cached_exist_find_by_client_guid_and_derp_and_user_guid")
     end
 
-    it "creates 'cached_exist_search_by_derp_and_user_guid_and_client_guid'" do
-      ExistMethodClass.must_respond_to("cached_exist_search_by_derp_and_user_guid_and_client_guid")
+    it "creates 'cached_exist_search_by_client_guid_and_derp_and_user_guid'" do
+      ExistMethodClass.must_respond_to("cached_exist_search_by_client_guid_and_derp_and_user_guid")
     end
 
     it "creates 'cached_exist_find_by_client_guid_and_derp_and_user_guid'" do
@@ -62,12 +62,12 @@ describe ExistMethodClass do
       ExistMethodClass.must_respond_to("cached_exist_search_by_client_guid_and_derp_and_user_guid")
     end
 
-    it "creates 'cached_exist_find_by_client_guid_and_user_guid_and_derp'" do
-      ExistMethodClass.must_respond_to("cached_exist_find_by_client_guid_and_user_guid_and_derp")
+    it "creates 'cached_exist_find_by_client_guid_and_derp_and_user_guid'" do
+      ExistMethodClass.must_respond_to("cached_exist_find_by_client_guid_and_derp_and_user_guid")
     end
 
-    it "creates 'cached_exist_search_by_client_guid_and_user_guid_and_derp'" do
-      ExistMethodClass.must_respond_to("cached_exist_search_by_client_guid_and_user_guid_and_derp")
+    it "creates 'cached_exist_search_by_client_guid_and_derp_and_user_guid'" do
+      ExistMethodClass.must_respond_to("cached_exist_search_by_client_guid_and_derp_and_user_guid")
     end
 
     # ? based methods
@@ -87,12 +87,12 @@ describe ExistMethodClass do
       ExistMethodClass.must_respond_to("cached_exist_search_by_user_guid?")
     end
 
-    it "creates 'cached_exist_find_by_user_guid_and_client_guid?'" do
-      ExistMethodClass.must_respond_to("cached_exist_find_by_user_guid_and_client_guid?")
+    it "creates 'cached_exist_find_by_client_guid_and_user_guid?'" do
+      ExistMethodClass.must_respond_to("cached_exist_find_by_client_guid_and_user_guid?")
     end
 
-    it "creates 'cached_exist_search_by_user_guid_and_client_guid?'" do
-      ExistMethodClass.must_respond_to("cached_exist_search_by_user_guid_and_client_guid?")
+    it "creates 'cached_exist_search_by_client_guid_and_user_guid?'" do
+      ExistMethodClass.must_respond_to("cached_exist_search_by_client_guid_and_user_guid?")
     end
 
     it "creates 'cached_exist_find_by_client_guid_and_user_guid?'" do
@@ -103,12 +103,12 @@ describe ExistMethodClass do
       ExistMethodClass.must_respond_to("cached_exist_search_by_client_guid_and_user_guid?")
     end
 
-    it "creates 'cached_exist_find_by_derp_and_user_guid_and_client_guid?'" do
-      ExistMethodClass.must_respond_to("cached_exist_find_by_derp_and_user_guid_and_client_guid?")
+    it "creates 'cached_exist_find_by_client_guid_and_derp_and_user_guid?'" do
+      ExistMethodClass.must_respond_to("cached_exist_find_by_client_guid_and_derp_and_user_guid?")
     end
 
-    it "creates 'cached_exist_search_by_derp_and_user_guid_and_client_guid?'" do
-      ExistMethodClass.must_respond_to("cached_exist_search_by_derp_and_user_guid_and_client_guid?")
+    it "creates 'cached_exist_search_by_client_guid_and_derp_and_user_guid?'" do
+      ExistMethodClass.must_respond_to("cached_exist_search_by_client_guid_and_derp_and_user_guid?")
     end
 
     it "creates 'cached_exist_find_by_client_guid_and_derp_and_user_guid?'" do
@@ -119,12 +119,12 @@ describe ExistMethodClass do
       ExistMethodClass.must_respond_to("cached_exist_search_by_client_guid_and_derp_and_user_guid?")
     end
 
-    it "creates 'cached_exist_find_by_client_guid_and_user_guid_and_derp?'" do
-      ExistMethodClass.must_respond_to("cached_exist_find_by_client_guid_and_user_guid_and_derp?")
+    it "creates 'cached_exist_find_by_client_guid_and_derp_and_user_guid?'" do
+      ExistMethodClass.must_respond_to("cached_exist_find_by_client_guid_and_derp_and_user_guid?")
     end
 
-    it "creates 'cached_exist_search_by_client_guid_and_user_guid_and_derp?'" do
-      ExistMethodClass.must_respond_to("cached_exist_search_by_client_guid_and_user_guid_and_derp?")
+    it "creates 'cached_exist_search_by_client_guid_and_derp_and_user_guid?'" do
+      ExistMethodClass.must_respond_to("cached_exist_search_by_client_guid_and_derp_and_user_guid?")
     end
   end
 end

--- a/spec/active_remote/cached_find_methods_spec.rb
+++ b/spec/active_remote/cached_find_methods_spec.rb
@@ -27,24 +27,12 @@ describe FindMethodClass do
       FindMethodClass.must_respond_to("cached_find_by_user_guid")
     end
 
-    it "creates 'cached_find_by_user_guid_and_client_guid'" do
-      FindMethodClass.must_respond_to("cached_find_by_user_guid_and_client_guid")
-    end
-
     it "creates 'cached_find_by_client_guid_and_user_guid'" do
       FindMethodClass.must_respond_to("cached_find_by_client_guid_and_user_guid")
     end
 
-    it "creates 'cached_find_by_derp_and_user_guid_and_client_guid'" do
-      FindMethodClass.must_respond_to("cached_find_by_derp_and_user_guid_and_client_guid")
-    end
-
     it "creates 'cached_find_by_client_guid_and_derp_and_user_guid'" do
       FindMethodClass.must_respond_to("cached_find_by_client_guid_and_derp_and_user_guid")
-    end
-
-    it "creates 'cached_find_by_client_guid_and_user_guid_and_derp'" do
-      FindMethodClass.must_respond_to("cached_find_by_client_guid_and_user_guid_and_derp")
     end
   end
 

--- a/spec/active_remote/cached_search_methods_spec.rb
+++ b/spec/active_remote/cached_search_methods_spec.rb
@@ -32,28 +32,16 @@ describe SearchMethodClass do
       SearchMethodClass.must_respond_to("cached_search_by_user_guid")
     end
 
-    it "creates 'cached_search_by_user_guid_and_client_guid'" do
-      SearchMethodClass.must_respond_to("cached_search_by_user_guid_and_client_guid")
-    end
-
     it "creates 'cached_search_by_client_guid_and_user_guid'" do
       SearchMethodClass.must_respond_to("cached_search_by_client_guid_and_user_guid")
-    end
-
-    it "creates 'cached_search_by_derp_and_user_guid_and_client_guid'" do
-      SearchMethodClass.must_respond_to("cached_search_by_derp_and_user_guid_and_client_guid")
     end
 
     it "creates 'cached_search_by_client_guid_and_derp_and_user_guid'" do
       SearchMethodClass.must_respond_to("cached_search_by_client_guid_and_derp_and_user_guid")
     end
 
-    it "creates 'cached_search_by_client_guid_and_user_guid_and_derp'" do
-      SearchMethodClass.must_respond_to("cached_search_by_client_guid_and_user_guid_and_derp")
-    end
-
-    it "creates 'cached_search_by_client_guid_and_user_guid_and_derp!'" do
-      SearchMethodClass.must_respond_to("cached_search_by_client_guid_and_user_guid_and_derp!")
+    it "creates 'cached_search_by_client_guid_and_derp_and_user_guid!'" do
+      SearchMethodClass.must_respond_to("cached_search_by_client_guid_and_derp_and_user_guid!")
     end
   end
 


### PR DESCRIPTION
This PR attempts to improve performance by sorting the parameter keys and making a single method instead of many permutations of the same method.

Calling `cached_finders_for` with more than a few params took a long time for very little gain. Here are the benchmarks I got on my own machine:

When calling `cached_finders_for` with 11 param keys:

```ruby
Benchmark.measure do 
  ::Institution.cached_finders_for(params.symbolize_keys.keys)  
end

=> Java::JavaLang::OutOfMemoryError: GC overhead limit exceeded
```

With this fix:

```ruby
Benchmark.measure do 
  ::Institution.cached_finders_for(params.symbolize_keys.keys)
end

=> #<Benchmark::Tms:0x39ec9a3b
 @cstime=0.0,
 @cutime=0.0,
 @label="",
 @real=3.882598348999636,
 @stime=0.03999999999999915,
 @total=4.1399999999999935,
 @utime=4.099999999999994>
```